### PR TITLE
Make ipv4-to-int about 3x faster

### DIFF
--- a/lib/IP/Random.pm6
+++ b/lib/IP/Random.pm6
@@ -51,10 +51,9 @@ module IP::Random:ver<0.0.2>:auth<cpan:JMASLAK> {
     }
 
     my sub ipv4-to-int($ascii) {
-        my $ipval = 0;
-        for $ascii.split('.') -> $part {
-            $ipval *= 256;
-            $ipval += $part;
+        my int $ipval = 0;
+        for $ascii.split('.') -> Int(Str) $part {
+            $ipval = $ipval +< 8 + $part;
         }
 
         return $ipval;


### PR DESCRIPTION
- use native ints and bit operations
- use explicit conversion: that seems to be the major improvement